### PR TITLE
[jules] Fix: Ensure max_tokens is an integer for OpenAI API

### DIFF
--- a/src/settings/ModelFormFieldSet.tsx
+++ b/src/settings/ModelFormFieldSet.tsx
@@ -66,7 +66,7 @@ export function ModelFormFieldSet({
               required
               {...form.getInputProps(`${formFieldModels}.${index}.temperature`)}
             />
-            <TextInput
+            <NumberInput
               label="Max Ouput Tokens"
               description="Max number of tokens to generate, leave blank for default."
               {...form.getInputProps(

--- a/src/settings/ModelFormFieldSet.tsx
+++ b/src/settings/ModelFormFieldSet.tsx
@@ -69,6 +69,7 @@ export function ModelFormFieldSet({
             <NumberInput
               label="Max Ouput Tokens"
               description="Max number of tokens to generate, leave blank for default."
+              min={1}
               {...form.getInputProps(
                 `${formFieldModels}.${index}.maxOutputTokens`
               )}

--- a/src/settings/ModelFormFieldSet.tsx
+++ b/src/settings/ModelFormFieldSet.tsx
@@ -67,9 +67,8 @@ export function ModelFormFieldSet({
               {...form.getInputProps(`${formFieldModels}.${index}.temperature`)}
             />
             <NumberInput
-              label="Max Ouput Tokens"
+              label="Max Output Tokens"
               description="Max number of tokens to generate, leave blank for default."
-              min={1}
               {...form.getInputProps(
                 `${formFieldModels}.${index}.maxOutputTokens`
               )}


### PR DESCRIPTION
The 'Max Output Tokens' field in the model settings was previously a TextInput, which caused its value to be saved as a string. This resulted in a "400 Invalid type" error when making calls to the OpenAI API, as the 'max_tokens' parameter expects an integer.

This commit changes the TextInput to a NumberInput for the 'Max Output Tokens' field in `src/settings/ModelFormFieldSet.tsx`. This ensures that the value is stored as a number (or undefined if left blank), resolving the API error.